### PR TITLE
fixed incorrect .ion write when directory is not .

### DIFF
--- a/sparc/ion.py
+++ b/sparc/ion.py
@@ -14,9 +14,6 @@ from ase.units import Bohr
 from ase.data import chemical_symbols, atomic_masses_iupac2016
 import warnings
 
-os.environ['SPARC_PSP_PATH'] = '$SPARC_PSP_PATH'
-
-
 def read_ion(fileobj, recover_indices=True, recover_constraints=True):
     text = fileobj.read()
     comments_removed = []
@@ -319,7 +316,7 @@ def decipher_constraints(constraints):
     return cons_list
 
 def write_ion(fileobj, atoms, pseudo_dir = None, scaled = True,
-              add_constraints = True, comment = '', directory=None):
+              add_constraints = True, comment = ''):
     """
     Standard ase io file for reading the sparc-x .ion format
     
@@ -330,8 +327,7 @@ def write_ion(fileobj, atoms, pseudo_dir = None, scaled = True,
             a list of the locations of the pseudopotential files to be used
     """
 
-    if directory == None:
-        directory = os.getcwd()
+    directory = os.path.dirname(fileobj.name)
 
     elements = sorted(list(set(atoms.get_chemical_symbols())))
     
@@ -468,5 +464,3 @@ def write_ion(fileobj, atoms, pseudo_dir = None, scaled = True,
         if 'spin_string' in locals():
             fileobj.write(spin_string)
         fileobj.write('\n\n')
-
-

--- a/sparc/sparc_core.py
+++ b/sparc/sparc_core.py
@@ -178,6 +178,7 @@ class SPARC(FileIOCalculator):
                                  'calculator object must have atoms attached to'
                                  ' write an input file')
             atoms = self.atoms
+
         FileIOCalculator.write_input(self, atoms)
 
 
@@ -419,9 +420,10 @@ class SPARC(FileIOCalculator):
                                         'pseudopotentials or pass in None for'
                                         ' the current directory to be used.')
             #kwargs['pseudo_dir'] = None
-        write_ion(open(self.label + '.ion','w'),
-                  atoms, pseudo_dir = kwargs['pseudo_dir'], scaled=scaled,
-                  directory=self.directory)
+
+        outpath = os.path.join(self.directory, self.label)
+        write_ion(open(outpath + '.ion','w'),
+                  atoms, pseudo_dir = kwargs['pseudo_dir'], scaled=scaled)
 
     def setup_parallel_env(self):
         """


### PR DESCRIPTION
I am not sure how robust this will be because there seems to be some ambiguity between whether `self.label` includes the directory path or not. I have assumed that it does not since that seems to be enforced in `__init__`, but you might want to check it.