### PR TITLE
Allow lazy import at root level

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -19,14 +19,8 @@ build:
     
 
 requirements:
-  build:
-    - "python>=3.8"
-    - setuptools
-    - "ase>=3.22"
-    - pip
   host:
     - "python>=3.8"
-    - "ase>=3.22"
     - pip
   run:
     - "python>=3.8"

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ test_requires = [
 
 setup(
     name="sparc-x-api",
-    version="1.0.0",
+    version="1.0.1",
     python_requires=">=3.8",
     description="Python API for the SPARC DFT Code",
     author="Tian Tian, Ben Comer",

--- a/sparc/__init__.py
+++ b/sparc/__init__.py
@@ -1,5 +1,35 @@
-from .io import read_sparc, write_sparc
-from .io import register_ase_io_sparc
-from .calculator import SPARC
+"""Initialization of sparc-x-api
 
-register_ase_io_sparc()
+For submodules like download_data and api, ase / numpy may be ignored,
+and run using standard python libaries. This may be useful for cases like
+conda build and CI where not all dependencies are present
+"""
+
+def _missing_deps_func(*args, **kwargs):
+    raise ImportError("Importing fails for ase / numpy!")
+
+class SPARCMissingDeps:
+    def __init__(self, *args, **kwargs):
+        raise ImportError("Cannot initialize sparc.SPARC because the required dependencies (ase and numpy) are not available.")
+
+    def __getattr__(self, name):
+        raise ImportError(f"Cannot access '{name}' on sparc.SPARC because the required dependencies (ase and numpy) are not available.")
+try:
+    import ase
+    import numpy
+    _import_complete = True
+except ImportError:
+    _import_complete = False
+
+if _import_complete:
+    from .io import read_sparc, write_sparc
+    from .io import register_ase_io_sparc
+    from .calculator import SPARC
+    register_ase_io_sparc()
+else:
+    # If importing is not complete, any code trying to directly import
+    # the following attributes will raise ImportError
+    read_sparc = _missing_deps_func
+    write_sparc = _missing_deps_func
+    SPARC = SPARCMissingDeps
+    

--- a/sparc/__init__.py
+++ b/sparc/__init__.py
@@ -5,18 +5,27 @@ and run using standard python libaries. This may be useful for cases like
 conda build and CI where not all dependencies are present
 """
 
+
 def _missing_deps_func(*args, **kwargs):
     raise ImportError("Importing fails for ase / numpy!")
 
+
 class SPARCMissingDeps:
     def __init__(self, *args, **kwargs):
-        raise ImportError("Cannot initialize sparc.SPARC because the required dependencies (ase and numpy) are not available.")
+        raise ImportError(
+            "Cannot initialize sparc.SPARC because the required dependencies (ase and numpy) are not available."
+        )
 
     def __getattr__(self, name):
-        raise ImportError(f"Cannot access '{name}' on sparc.SPARC because the required dependencies (ase and numpy) are not available.")
+        raise ImportError(
+            f"Cannot access '{name}' on sparc.SPARC because the required dependencies (ase and numpy) are not available."
+        )
+
+
 try:
     import ase
     import numpy
+
     _import_complete = True
 except ImportError:
     _import_complete = False
@@ -25,6 +34,7 @@ if _import_complete:
     from .io import read_sparc, write_sparc
     from .io import register_ase_io_sparc
     from .calculator import SPARC
+
     register_ase_io_sparc()
 else:
     # If importing is not complete, any code trying to directly import
@@ -32,4 +42,3 @@ else:
     read_sparc = _missing_deps_func
     write_sparc = _missing_deps_func
     SPARC = SPARCMissingDeps
-    

--- a/sparc/utils.py
+++ b/sparc/utils.py
@@ -11,9 +11,7 @@ def deprecated(message):
     def decorator(func):
         def new_func(*args, **kwargs):
             warn(
-                "Function {} is deprecated! {}".format(
-                    func.__name__, message
-                ),
+                "Function {} is deprecated! {}".format(func.__name__, message),
                 category=DeprecationWarning,
             )
             return func(*args, **kwargs)

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -4,44 +4,25 @@ should such modules are not yet available during processes like conda-forge buil
 """
 import pytest
 import sys
+import ase
 
-def test_download_data():
-    import ase
-    original_ase = sys.modules.get('ase')
-    sys.modules['ase'] = None
+
+def test_download_data(monkeypatch):
+    monkeypatch.setitem(sys.modules, "ase", None)
     with pytest.raises(ImportError):
         import ase
     from sparc.download_data import download_psp
-    # Recover sys ase
-    sys.modules['ase'] = original_ase
 
-def test_api():
-    import ase
-    original_ase = sys.modules.get('ase')
-    sys.modules['ase'] = None
+
+def test_api(monkeypatch):
+    monkeypatch.setitem(sys.modules, "ase", None)
     with pytest.raises(ImportError):
         import ase
     from sparc.api import SparcAPI
-    # Recover sys ase
-    sys.modules['ase'] = original_ase
 
-def test_docparser():
-    import ase
-    original_ase = sys.modules.get('ase')
-    sys.modules['ase'] = None
+
+def test_docparser(monkeypatch):
+    monkeypatch.setitem(sys.modules, "ase", None)
     with pytest.raises(ImportError):
         import ase
     from sparc.docparser import SPARCDocParser
-    # Recover sys ase
-    sys.modules['ase'] = original_ase
-
-def test_normal():
-    import ase
-    original_ase = sys.modules.get('ase')
-    sys.modules['ase'] = None
-    with pytest.raises(ImportError):
-        import ase
-    with pytest.raises(ImportError):
-        from sparc.io import read_sparc
-    # Recover sys ase
-    sys.modules['ase'] = original_ase

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,47 @@
+"""Unit test for order of importing.
+Submodules like `docparser` `api` and `download_data` should be independent of ase / numpy,
+should such modules are not yet available during processes like conda-forge build
+"""
+import pytest
+import sys
+
+def test_download_data():
+    import ase
+    original_ase = sys.modules.get('ase')
+    sys.modules['ase'] = None
+    with pytest.raises(ImportError):
+        import ase
+    from sparc.download_data import download_psp
+    # Recover sys ase
+    sys.modules['ase'] = original_ase
+
+def test_api():
+    import ase
+    original_ase = sys.modules.get('ase')
+    sys.modules['ase'] = None
+    with pytest.raises(ImportError):
+        import ase
+    from sparc.api import SparcAPI
+    # Recover sys ase
+    sys.modules['ase'] = original_ase
+
+def test_docparser():
+    import ase
+    original_ase = sys.modules.get('ase')
+    sys.modules['ase'] = None
+    with pytest.raises(ImportError):
+        import ase
+    from sparc.docparser import SPARCDocParser
+    # Recover sys ase
+    sys.modules['ase'] = original_ase
+
+def test_normal():
+    import ase
+    original_ase = sys.modules.get('ase')
+    sys.modules['ase'] = None
+    with pytest.raises(ImportError):
+        import ase
+    with pytest.raises(ImportError):
+        from sparc.io import read_sparc
+    # Recover sys ase
+    sys.modules['ase'] = original_ase


### PR DESCRIPTION
Some submodules like `sparc.api`, `sparc.download_data` and `sparc.docparser` may not need ase / numpy dependency, but do need information like where the package is installed / built. Allowing lazy import at root level can be helpful for things like conda-forge build, where scripts like `sparc.download_data` is needed after package installation, but the build host couldn't contain the ase / numpy packages, see https://github.com/conda-forge/staged-recipes/pull/24093