### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/installation_test.yml
+++ b/.github/workflows/installation_test.yml
@@ -44,7 +44,7 @@ jobs:
         # unzip master.zip
         wget -O SPARC-master.zip https://codeload.github.com/SPARC-X/SPARC/zip/525e94c82345f1e8741a76599e4b2818dfb549a9
         unzip SPARC-master.zip
-        mv SPARC-33* SPARC-master
+        mv SPARC-52* SPARC-master
     - name: Test with pytest
       run: |
         # python -m pytest -svv tests/ --cov=sparc --cov-report=json --cov-report=html

--- a/.github/workflows/installation_test.yml
+++ b/.github/workflows/installation_test.yml
@@ -42,7 +42,7 @@ jobs:
         # Pin the current version of SPARC to versions before MLFF
         # wget https://github.com/SPARC-X/SPARC/archive/refs/heads/master.zip
         # unzip master.zip
-        wget -O SPARC-master.zip https://codeload.github.com/SPARC-X/SPARC/zip/3371b4401e4ebca0921fb77a02587f578f3bf3f7
+        wget -O SPARC-master.zip https://codeload.github.com/SPARC-X/SPARC/zip/525e94c82345f1e8741a76599e4b2818dfb549a9
         unzip SPARC-master.zip
         mv SPARC-33* SPARC-master
     - name: Test with pytest

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -110,7 +110,7 @@ jobs:
         export SPARC_TESTS_DIR="./SPARC-master/tests"
         export ASE_SPARC_COMMAND="mpirun -n 1 sparc"
         export SPARC_DOC_PATH="./SPARC-master/doc/.LaTeX"
-        python -m pytest -svv tests/read_all_examples.py
+        python -m pytest -svv tests/test_read_all_examples.py
 
   test-socket:
     defaults:

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -1,4 +1,4 @@
-name: unit tests
+name: Unit tests for SPARC-X-API
 
 on:
   push:
@@ -10,60 +10,44 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-linux:
+  test-linux:
     defaults:
       run:
         shell: bash -l {0}
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
 
     steps:
     - uses: actions/checkout@v3
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: "3.10"
         mamba-version: "*"
-        channels: conda-forge,alchem0x2a,defaults
+        channels: conda-forge,defaults
         channel-priority: true
         activate-environment: sparc-api-test
     - name: Install dependencies
       run: |
-        # mamba install -c conda-forge ase>=3.22 pymatgen flake8 pytest
         mamba install -c conda-forge sparc-x
-        # pip install pyfakefs
     - name: Install package
       run: |
         pip install -e ".[test]"
         # Download the external psp data
         python -m sparc.download_data
-    - name: Download SPARC output files to SPARC-master
-      run: |
-        # Pin the current version of SPARC to versions before MLFF
-        # wget https://github.com/SPARC-X/SPARC/archive/refs/heads/master.zip
-        # unzip master.zip
-        wget -O SPARC-master.zip https://codeload.github.com/SPARC-X/SPARC/zip/525e94c82345f1e8741a76599e4b2818dfb549a9
-        unzip SPARC-master.zip
-        mv SPARC-52* SPARC-master
-    - name: Test with pytest
-      run: |
-        # python -m pytest -svv tests/ --cov=sparc --cov-report=json --cov-report=html
-        export SPARC_TESTS_DIR="./SPARC-master/tests"
-        export ASE_SPARC_COMMAND="mpirun -n 1 sparc"
-        export SPARC_DOC_PATH="./SPARC-master/doc/.LaTeX"
-        coverage run -a -m pytest -svv tests/
-        coverage json --omit="tests/*.py"
-        coverage html --omit="tests/*.py"
-        COVERAGE=`cat coverage.json | jq .totals.percent_covered | xargs printf '%.*f' 0`
-        echo "Current coverage is $COVERAGE"
-        echo "COVPERCENT=$COVERAGE" >> $GITHUB_ENV
-
     - name: Lint with flake8
       run: |
         echo $CONDA_PREFIX
         conda info
         flake8 sparc/ --count --select=E9,F63,F7,F82 --show-source --statistics
         flake8 sparc/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest (without all SPARC examples)
+      run: |
+        export ASE_SPARC_COMMAND="mpirun -n 1 sparc"
+        coverage run -a -m pytest -svv tests/
+        coverage json --omit="tests/*.py"
+        coverage html --omit="tests/*.py"
+        COVERAGE=`cat coverage.json | jq .totals.percent_covered | xargs printf '%.*f' 0`
+        echo "Current coverage is $COVERAGE"
+        echo "COVPERCENT=$COVERAGE" >> $GITHUB_ENV
     - name: SPARC API version
       run: |
         python -c "from sparc.api import SparcAPI; import os; ver=SparcAPI().sparc_version; os.system(f'echo API_VERSION={ver} >> $GITHUB_ENV')"
@@ -93,26 +77,59 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         RID: ${{ github.run_id }}
 
+  parse-sparc-official-examples:
+    defaults:
+      run:
+        shell: bash -l {0}
+    runs-on: ubuntu-latest
+    needs: test-linux
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: conda-incubator/setup-miniconda@v3
+      with:
+        python-version: "3.10"
+        mamba-version: "*"
+        channels: conda-forge,defaults
+        channel-priority: true
+        activate-environment: sparc-api-test
+    - name: Install dependencies
+      run: |
+        mamba install -c conda-forge sparc-x
+    - name: Install package
+      run: |
+        pip install -e ".[test]"
+        # Download the external psp data
+        python -m sparc.download_data
+    - name: Download SPARC output files to SPARC-master
+      run: |
+        wget https://github.com/SPARC-X/SPARC/archive/refs/heads/master.zip
+        unzip master.zip
+    - name: Test with pytest on official examples
+      run: |
+        export SPARC_TESTS_DIR="./SPARC-master/tests"
+        export ASE_SPARC_COMMAND="mpirun -n 1 sparc"
+        export SPARC_DOC_PATH="./SPARC-master/doc/.LaTeX"
+        python -m pytest -svv tests/read_all_examples.py
+
   test-socket:
     defaults:
       run:
         shell: bash -l {0}
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
+    needs: test-linux
 
     steps:
     - uses: actions/checkout@v3
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: "3.10"
         mamba-version: "*"
-        channels: conda-forge,alchem0x2a,defaults
+        channels: conda-forge,defaults
         channel-priority: true
         activate-environment: sparc-api-test
     - name: Install dependencies
       run: |
-        # mamba install -c conda-forge ase>=3.22 pymatgen flake8 pytest
         mamba install -c conda-forge make compilers openmpi fftw scalapack openblas
     - name: Install package
       run: |
@@ -134,79 +151,7 @@ jobs:
       run: |
         ls ./SPARC-socket/lib/sparc
         PWD=$(pwd)
-        export SPARC_TESTS_DIR="${PWD}/SPARC-socket/tests"
+        #export SPARC_TESTS_DIR="${PWD}/SPARC-socket/tests"
         export ASE_SPARC_COMMAND="mpirun -n 1 ${PWD}/SPARC-socket/lib/sparc"
         export SPARC_DOC_PATH="${PWD}/SPARC-socket/doc/.LaTeX"
-        coverage run -a -m pytest -svv tests/
-        coverage json --omit="tests/*.py"
-        coverage html --omit="tests/*.py"
-        COVERAGE=`cat coverage.json | jq .totals.percent_covered | xargs printf '%.*f' 0`
-        echo "Current coverage is $COVERAGE"
-        echo "COVPERCENT=$COVERAGE" >> $GITHUB_ENV
-
-    - name: Lint with flake8
-      run: |
-        echo $CONDA_PREFIX
-        conda info
-        flake8 sparc/ --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 sparc/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-
-  # To be deleted once 1.0 release is done
-  build-linux-ase-3-22:
-    defaults:
-      run:
-        shell: bash -l {0}
-    runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 5
-
-    steps:
-    - uses: actions/checkout@v3
-    - uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: "3.10"
-        mamba-version: "*"
-        channels: conda-forge,alchem0x2a,defaults
-        channel-priority: true
-        activate-environment: sparc-api-test
-    - name: Install dependencies
-      run: |
-        # mamba install -c conda-forge ase>=3.22 pymatgen flake8 pytest
-        mamba install -c conda-forge make compilers openmpi fftw scalapack openblas
-    - name: Install package
-      run: |
-        pip install -e ".[test]" ase==3.22 numpy==1.24 scipy==1.10
-        # Manually downgrade
-        # Download the external psp data
-        python -m sparc.download_data
-    - name: Download SPARC output files to SPARC-master
-      run: |
-        # TODO: merge to master
-        wget -O SPARC-socket.zip https://codeload.github.com/alchem0x2A/SPARC/zip/refs/heads/socket
-        unzip SPARC-socket.zip
-    - name: Compile SPARC with socket
-      run: |
-        cd SPARC-socket/src
-        make clean
-        make -j2 USE_SOCKET=1 USE_MKL=0 USE_SCALAPACK=1 DEBUG_MODE=1
-        ls ../lib
-    - name: Test with pytest
-      run: |
-        ls ./SPARC-socket/lib/sparc
-        PWD=$(pwd)
-        export SPARC_TESTS_DIR="${PWD}/SPARC-socket/tests"
-        export ASE_SPARC_COMMAND="mpirun -n 1 ${PWD}/SPARC-socket/lib/sparc"
-        export SPARC_DOC_PATH="${PWD}/SPARC-socket/doc/.LaTeX"
-        coverage run -a -m pytest -svv tests/
-        coverage json --omit="tests/*.py"
-        coverage html --omit="tests/*.py"
-        COVERAGE=`cat coverage.json | jq .totals.percent_covered | xargs printf '%.*f' 0`
-        echo "Current coverage is $COVERAGE"
-        echo "COVPERCENT=$COVERAGE" >> $GITHUB_ENV
-
-    - name: Lint with flake8
-      run: |
-        echo $CONDA_PREFIX
-        conda info
-        flake8 sparc/ --count --select=E9,F63,F7,F82 --show-source --statistics
-        flake8 sparc/ --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        python -m pytest -svv tests/test_socket.py

--- a/tests/test_api_version.py
+++ b/tests/test_api_version.py
@@ -29,14 +29,14 @@ def test_sparc_api(monkeypatch):
 
 def test_sparc_params():
     if "SPARC_DOC_PATH" not in os.environ:
-        pytest.skip(msg="No $SPARC_DOC_PATH set. Skip")
+        pytest.skip("No $SPARC_DOC_PATH set. Skip")
 
     from sparc.utils import locate_api
 
     # Use the default api with SPARC_DOC_PATH
     api = locate_api()
     if api.sparc_version is None:
-        pytest.skip(msg="SPARC version not known. skip")
+        pytest.skip("SPARC version not known. skip")
 
     if version.parse(api.sparc_version) > version.parse("2023.09.01"):
         assert "NPT_SCALE_VECS" in api.parameters

--- a/tests/test_read_all_examples.py
+++ b/tests/test_read_all_examples.py
@@ -3,7 +3,7 @@
 The test needs to be combined with the downloadable test outputs from SPARC-X's repo
 and will only be activated when the environment variable $SPARC_TESTS_DIR is set
 
-The ref
+
 """
 import os
 import shutil


### PR DESCRIPTION
Some minor changes to the CI workflow
- Separate unit tests from parsing official SPARC test input files / socket tests. 
- Update some CI action versions
- Fix pytest deprecation of msg keyword

Until the upstream SPARC doc is updated, the CI workflow for official sparc files will fail, which is also a good way to inform SPARC core developers about inconsistency in the doc and/or missing parameters in doc