### PR TITLE
Add configuration file

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -141,7 +141,7 @@ jobs:
     - name: Download SPARC output files to SPARC-master
       run: |
         # Use latest SPARC public code with socket support
-        HASH=SPARC-99e4b7e94ca6f7b4ca1dde9135bea4075b0678f4
+        HASH=99e4b7e94ca6f7b4ca1dde9135bea4075b0678f4
         wget -O SPARC-socket.zip https://codeload.github.com/SPARC-X/SPARC/zip/$HASH
         mv SPARC-$HASH SPARC-socket
         unzip SPARC-socket.zip

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -143,8 +143,8 @@ jobs:
         # Use latest SPARC public code with socket support
         HASH=99e4b7e94ca6f7b4ca1dde9135bea4075b0678f4
         wget -O SPARC-socket.zip https://codeload.github.com/SPARC-X/SPARC/zip/$HASH
+        unzip SPARC-socket.zip && rm -rf SPARC-socket.zip
         mv SPARC-$HASH SPARC-socket
-        unzip SPARC-socket.zip
     - name: Compile SPARC with socket
       run: |
         cd SPARC-socket/src

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -141,7 +141,9 @@ jobs:
     - name: Download SPARC output files to SPARC-master
       run: |
         # Use latest SPARC public code with socket support
-        wget -O SPARC-socket.zip https://codeload.github.com/SPARC-X/SPARC/zip/99e4b7e94ca6f7b4ca1dde9135bea4075b0678f4
+        HASH=SPARC-99e4b7e94ca6f7b4ca1dde9135bea4075b0678f4
+        wget -O SPARC-socket.zip https://codeload.github.com/SPARC-X/SPARC/zip/$HASH
+        mv SPARC-$HASH SPARC-socket
         unzip SPARC-socket.zip
     - name: Compile SPARC with socket
       run: |

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -122,10 +122,10 @@ jobs:
     needs: test-linux
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: conda-incubator/setup-miniconda@v3
       with:
-        python-version: "3.10"
+        python-version: "3.11"
         mamba-version: "*"
         channels: conda-forge,defaults
         channel-priority: true
@@ -140,8 +140,8 @@ jobs:
         python -m sparc.download_data
     - name: Download SPARC output files to SPARC-master
       run: |
-        # TODO: merge to master
-        wget -O SPARC-socket.zip https://codeload.github.com/alchem0x2A/SPARC/zip/refs/heads/socket
+        # Use latest SPARC public code with socket support
+        wget -O SPARC-socket.zip https://codeload.github.com/SPARC-X/SPARC/zip/99e4b7e94ca6f7b4ca1dde9135bea4075b0678f4
         unzip SPARC-socket.zip
     - name: Compile SPARC with socket
       run: |

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ Preferences for SPARC-X-API and SPARC C/C++ code can be defined in ASE [configur
 ; `command`: full shell command (include MPI directives) to run SPARC
 command = srun -n 24 path/to/sparc
 
-; `pp_path`: directory containing pseudopotential files (optional)
-pp_path = path/to/SPARC/psps
+; `psp_path`: directory containing pseudopotential files (optional)
+psp_path = path/to/SPARC/psps
 
 ; `doc_path`: directory for SPARC LaTeX documentation to build JSON schema on the fly (optional)
 doc_path = path/to/SPARC/doc/.LaTeX/

--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ Install the pre-compiled SPARC binary alongside SPARC-X-API (Linux only).
 conda install -c conda-forge sparc-x
 ```
 
+### Setup SPARC-X-API
+
+Preferences for SPARC-X-API and SPARC C/C++ code can be defined in ASE [configuration file](https://wiki.fysik.dtu.dk/ase/ase/calculators/calculators.html#calculator-configuration), located at `~/.config/ase/config.ini`, such as following example:
+
+```ini
+[sparc]
+; `command`: full shell command (include MPI directives) to run SPARC
+command = srun -n 24 path/to/sparc
+
+; `pp_path`: directory containing pseudopotential files (optional)
+pp_path = path/to/SPARC/psps
+
+; `doc_path`: directory for SPARC LaTeX documentation to build JSON schema on the fly (optional)
+doc_path = path/to/SPARC/doc/.LaTeX/
+```
+
 ### Reading / Writing SPARC files
 
 SPARC-X-API provides a file format `sparc` compatible with the ASE

--- a/README.md
+++ b/README.md
@@ -68,12 +68,14 @@ in-/output files as a bundle:
 
 - Read from a SPARC bundle
 ```python
+# `format="sparc"` should be specified
 from ase.io import read
 atoms = read("sparc_calc_dir/", format="sparc")
 ```
 
 - Write input files
 ```python
+# `format="sparc"` should be specified
 from ase.build import Bulk
 atoms = Bulk("Al") * [4, 4, 4]
 atoms.write("sparc_calc_dir/", format="sparc")

--- a/doc/advanced_socket.md
+++ b/doc/advanced_socket.md
@@ -21,10 +21,14 @@ Fig. 1. SPARC electronic calculations with socket communication across hybrid co
 ```
 
 **Requirements**: the SPARC binary must be manually compiled from the source
-code with [socket
-support](https://github.com/alchem0x2A/SPARC/tree/socket) and with the
+code with socket
+support and with the
 `USE_SOCKET=1` flag enabled (see the [installation
-instructions](https://github.com/alchem0x2A/SPARC/tree/socket).
+instructions](https://github.com/SPARC-X/SPARC?tab=readme-ov-file#2-installation).
+
+```{note}
+You need SPARC C/C++ after version 2024.11.18 to enable socket support.
+```
 
 ## Usage
 The socket communication layer in SPARC and SPARC-X-API are designed for:
@@ -38,11 +42,11 @@ standard. Specifically, we implement the original i-PI protocol within
 the SPARC C-source code, while the python SPARC-X-API uses a
 backward-compatible protocol based on i-PI. The dual-mode design is
 aimed for both low-level and high-level interfacing of the DFT codes,
-providing the following features as shown in [Fig. 2](#SPARC-protocol-overview):
+providing the following features as shown in [Fig. 2](#scheme-sparc-protocol):
 
-(scheme-sparc-protocol)=
 ```{figure} img/scheme_sparc_protocol.png
 :alt: scheme-sparc-protocol
+:name: scheme-sparc-protocol
 
 Fig. 2. Overview of the SPARC protocol as an extension to the standard i-PI protocol.
 ```
@@ -51,8 +55,8 @@ Based on the scenarios, the socket communication layer can be accessed
 via the following approaches as shown in
 [Fig. 3](#scheme-sparc-modes):
 
-(scheme-sparc-modes)=
 ```{figure} img/scheme-SPARC-socket-modes.png
+:name: scheme-sparc-modes
 :alt: scheme-sparc-modes
 
 Fig. 3. Different ways of using SPARC's socket mode.
@@ -81,7 +85,7 @@ Fig. 3. Different ways of using SPARC's socket mode.
    to be run on a single computer system.
 
 
-2. **Local-only Mode** ([Fig. 3](#scheme-sparc-modes) **b**)
+2. **Local-only mode** ([Fig. 3](#scheme-sparc-modes) **b**)
 
    Ideal for standalone calculations, this mode simulates a conventional calculator while benefiting from socket-based efficiency.
 
@@ -91,7 +95,7 @@ Fig. 3. Different ways of using SPARC's socket mode.
    ```
    For most users we recommend using this mode when performing a calculation on a single HPC node.
 
-3. **Client (Relay) Mode** ([Fig. 3](#scheme-sparc-modes) **c**)
+3. **Client (Relay) mode** ([Fig. 3](#scheme-sparc-modes) **c**)
 
    In this mode, the `sparc.SPARC` calculator servers as a passive
    client which listens to a remote i-PI-compatible server. When
@@ -119,7 +123,7 @@ Fig. 3. Different ways of using SPARC's socket mode.
    automatically determine if it is necessary to restart the SPARC
    subprocess.
 
-4. **Server Mode** ([Fig. 3](#scheme-sparc-modes) **d**)
+4. **Server mode** ([Fig. 3](#scheme-sparc-modes) **d**)
 
    Paired with the client mode in (3), SPARC-X-API can be run as a
    socket server, isolated from the node that performs the

--- a/doc/advanced_topics.md
+++ b/doc/advanced_topics.md
@@ -93,7 +93,7 @@ old_atoms.get_potential_energy()
 ```
 
 
-
+(rule-input-param)=
 ## Rules for input parameters in `sparc.SPARC` calculator
 
 When constructing the `sparc.SPARC` calculator using the syntax

--- a/doc/basic_usage.md
+++ b/doc/basic_usage.md
@@ -13,7 +13,7 @@ file format:
 ```python
 import sparc
 from ase.io import read, write
-atoms = read("test.sparc", index=-1)
+atoms = read("test.sparc", index=-1, format="sparc")
 ```
 *Note*: To read multiple output files from the same directory, e.g., SPARC.aimd, SPARC.aimd\_01, pass the keyword argument `include_all_files=True` to `read()`
 
@@ -24,7 +24,11 @@ import sparc
 from ase.io import read, write
 from ase.build import Bulk
 atoms = Bulk("Al") * [4, 4, 4]
-atoms.write("test.sparc")
+atoms.write("test.sparc", format="sparc")
+```
+
+```{note}
+You need to specify `format="sparc"` when using the `read` and `write` functions from `ase.io`, as automatic file extension detection doesn't work for directories.
 ```
 
 For a deeper dive into the bundle I/O format, see [Advanced Topics](advanced_topics.md).

--- a/doc/basic_usage.md
+++ b/doc/basic_usage.md
@@ -109,7 +109,7 @@ If you want to extract more information about the MD simulation steps, take a lo
 
 4. Geometric optimization using ASE's optimizers
 
-The power of `SPARC-X-API` is to combine single point `SPARC` calculations with advanced ASE optimizers, such as BFGS, FIRE or GPMin. Example 2 can be re-written as:
+The power of `SPARC-X-API` is to combine single point `SPARC` calculations with advanced ASE optimizers, such as `BFGS`, `FIRE` or `GPMin`. Example 2 can be re-written as:
 
 ```python
 from sparc.calculator import SPARC
@@ -133,11 +133,14 @@ for the visualization of atomistic structures. Depending on the
 bundle's contents, this could display individual atoms or multiple
 images.
 
-[Fig. 2](#fig-2-a-screenshot-of-the-sparc-ase-program) is a screenshot showing the usage of `sparc-ase gui` to visualize a
-short [MD trajectory](tests/outputs/NH3_sort_lbfgs_opt.sparc).
+[Fig. 1](#fig-screenshot-sparc-ase) is a screenshot showing the usage of `sparc-ase gui` to visualize a
+short MD trajectory.
 
-#### Fig 2. A screenshot of the `sparc-ase` program
-<img width="1200" alt="image" src="https://github.com/alchem0x2A/SPARC-X-API/assets/6829706/e72329ff-7194-4819-94f8-486ef2218844">
+(fig-screenshot-sparc-ase)=
+```{figure} https://github.com/alchem0x2A/SPARC-X-API/assets/6829706/e72329ff-7194-4819-94f8-486ef2218844
+
+Fig 1. A screenshot of the `sparc-ase` program
+```
 
 ### Parameters and units used in `SPARC-X-API`
 
@@ -149,7 +152,7 @@ atoms.calc = SPARC(h=0.25, REFERENCE_CUTOFF=0.5, EXX_RANGE_PBE=0.16, **params)
 ```
 inputs following ASE's convention (e.g., `h`) adopt eV/Angstrom units (thus the same setting can be applied to other DFT calculators),
 On the other hand, all SPARC-specific parameters, which can often be recognized by their capitalized format (like `REFERENCE_CUTOFF`, `EXX_RANGE_PBE`), retain their original values consistent with their representation in the `.inpt` files.
-The reasoning and details about unit conversion can be found in the [Rules for Input Parameters](https://github.com/alchem0x2A/SPARC-X-API/blob/master/doc/advanced_topics.md#rules-for-input-parameters-in-sparcsparc-calculator)  in Advanced Topics.
+The reasoning and details about unit conversion can be found in the [Rules for Input Parameters](#rule-input-param)  in Advanced Topics.
 
 
 In order for `SPARC-X-API` to be compatible with other ASE-based DFT calculators,

--- a/doc/contribute.md
+++ b/doc/contribute.md
@@ -51,7 +51,7 @@ for pre-commit hooks used in this project, and change them if needed.
 If you need to test running DFT using the API, compile or install the
 `sparc` executables following the
 [manual](https://github.com/SPARC-X/SPARC/blob/master/README.md). Check
-[some examples](#install-the-sparc-binary-code) for our recommended
+[some examples](#install-binary) for our recommended
 approaches.
 
 
@@ -109,7 +109,7 @@ flavor](https://myst-parser.readthedocs.io/en/latest/) of
 Markdown. The source `.md` files, together with the main `README.md`
 are then rendered to html files using `sphinx`.
 
-After [setting up the test environment](#setting-up-environment),
+After [setting up the test environment](setup_environment.md),
 additional packages for doc rendering can be installed via:
 ```bash
 cd SPARC-X-API
@@ -145,55 +145,7 @@ computating power (e.g. a few minutes with 4 CPU cores).
 Please check the [maintenance guide](maintainers.md) for roles
 involving admin privileges.
 
-<!-- ### Code structure -->
-
-<!-- Below is a brief overview of the modules in `SPARC-X-API` with simple explanations -->
-<!-- ``` -->
-<!-- sparc -->
-<!-- ├── __init__.py -->
-<!-- ├── api.py                 # Includes SparcAPI class for parameter validation -->
-<!-- ├── calculator.py          # Interface to the SPARC DFT code -->
-<!-- ├── cli.py                 # `sparc-ase` interface -->
-<!-- ├── common.py              # Definition of common directories -->
-<!-- ├── docparser.py           # Function and cli interface for parsing the SPARC DFT document -->
-<!-- ├── download_data.py       # Cli tool to download pseudopotential files -->
-<!-- ├── io.py                  # Provides `SparcBundle` class, `read_sparc` and `write_sparc` functions -->
-<!-- ├── quicktest.py           # Cli tool for post-installation sanity check -->
-<!-- ├── utils.py               # Common utilities -->
-<!-- ├── psp/                   # Place-holder directory for pseudopotentials (used for `download_data.py`) -->
-<!-- ├── sparc_json_api         # Directory for maintaining the JSON API -->
-<!-- │   └── parameters.json -->
-<!-- ├── sparc_parsers          # Parsers for individual SPARC in-/output formats -->
-<!-- │   ├── __init__.py -->
-<!-- │   ├── aimd.py -->
-<!-- │   ├── atoms.py -->
-<!-- │   ├── geopt.py -->
-<!-- │   ├── inpt.py -->
-<!-- │   ├── ion.py -->
-<!-- │   ├── out.py -->
-<!-- │   ├── pseudopotential.py -->
-<!-- │   ├── static.py -->
-<!-- │   └── utils.py -->
-<!-- ``` -->
-
-<!-- ### CI/CD by Github Actions -->
-
-<!-- The repo contains a few CI/CD pipelines based on Github Actions. You -->
-<!-- may need to take care of the settings if you're one of the -->
-<!-- maintainers. For normal code contributors, this section may be -->
-<!-- omitted. -->
-
-<!-- - Unit test -->
-
-<!-- The steps are described [here](.github/workflows/installation_test.yml). -->
-<!-- Please make sure to exclude any computationally-heavy tests from the step "Test with pytest". -->
-
-<!-- - Coverage -->
-
-<!-- The CI workflow contains a coverage report step based on the unit test -->
-<!-- and generates a [coverage -->
-<!-- badge](https://github.com/SPARC-X/SPARC-X-API/blob/badges/badges/coverage.svg) -->
-<!-- on the [`badges` -->
-<!-- branch](https://github.com/SPARC-X/SPARC-X-API/tree/badges). -->
-
-<!-- For repo maintainers, please make sure the `badges` branch is present and **do not merge to this branch**. -->
+```{toctree}
+:max_depth: 1
+test_coverage.md
+```

--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -1,1 +1,0 @@
-# Introduction

--- a/doc/setup_environment.md
+++ b/doc/setup_environment.md
@@ -42,9 +42,9 @@ are grouped in sections. An example of the SPARC-specific section may look like 
 ;            has the same effect as `ASE_SPARC_COMMAND`
 command = srun -n 24 ~/bin/sparc
 
-; `pp_path`: directory containing pseudopotential files
-;            has the same effect as `SPARC_PP_PATH`
-pp_path = ~/dev_SPARC/psps
+; `psp_path`: directory containing pseudopotential files
+;            has the same effect as `SPARC_PSP_PATH`
+psp_path = ~/dev_SPARC/psps
 
 ; `doc_path`: directory for SPARC LaTeX documentation
 ;             has the same effect as `SPARC_DOC_PATH`
@@ -60,7 +60,7 @@ The available options in the configuration file are:
    define a custom JSON schema file, or `doc_path` for parsing the
    LaTeX documentation on-the-fly. See [JSON schema
    configuration](#json-schema-setting) for more details.
-3. Pseudopotential settings (*Optional*): use `pp_path` for the
+3. Pseudopotential settings (*Optional*): use `psp_path` for the
    location of pseudopotential files. See [pseudopotential files settings](#pseudopot-setting)
    for more details.
 

--- a/doc/setup_environment.md
+++ b/doc/setup_environment.md
@@ -160,7 +160,7 @@ python -c "from sparc.common import psp_dir; print(psp_dir)"
 ```
 
 (sparc-cmd-setting)=
-### SPARC Command Configuration
+### SPARC command configuration
 
 The command to execute SPARC calculations is determined based on the
 following priority:
@@ -291,7 +291,7 @@ sparc_socket_compatibility: False
 --------------------------------------------------------------------------------
 Please check additional information from:
 1. SPARC&apos;s documentation: https://github.com/SPARC-X/SPARC/blob/master/doc/Manual.pdf
-2. Python API documentation: https://github.com/alchem0x2A/SPARC-X-API/blob/master/README.md
+2. Python API documentation: https://github.com/SPARC-X/SPARC-X-API/blob/master/README.md
 
 </pre>
 </div>

--- a/doc/setup_environment.md
+++ b/doc/setup_environment.md
@@ -18,10 +18,57 @@ configurations. The default configurations are:
 
 ## Custom configurations
 
-**TODO** use sparc ini config.
+You can configure the setup for SPARC-X-API using either of the
+following methods:
+1. (Recommended) use the [ASE configuration file](https://wiki.fysik.dtu.dk/ase/ase/calculators/calculators.html#calculator-configuration)
+2. Use environmental variables. Please note although environmental
+   variables have long been the standard approach to set
+   ASE-calculators, they may be obsolete in future releases of ASE.
 
-Please check the following steps for detailed setup:
+```{note}
+The environmental variables will have **higher priority** than the equivalent fields in the configure file, if both are set.
+```
 
+### Editing the configuration file
+
+ASE will look for a configuration file at `~/.config/ase/config.ini`
+for package-specific settings. The configuration file follows the [INI
+format](https://en.wikipedia.org/wiki/INI_file), where key-value pairs
+are grouped in sections. An example of the SPARC-specific section may look like follows:
+
+```{code} ini
+[sparc]
+; `command`: full shell command (include MPI directives) to run SPARC calculation
+;            has the same effect as `ASE_SPARC_COMMAND`
+command = srun -n 24 ~/bin/sparc
+
+; `pp_path`: directory containing pseudopotential files
+;            has the same effect as `SPARC_PP_PATH`
+pp_path = ~/dev_SPARC/psps
+
+; `doc_path`: directory for SPARC LaTeX documentation
+;             has the same effect as `SPARC_DOC_PATH`
+doc_path = ~/dev_SPARC/doc/.LaTeX/
+```
+
+The available options in the configuration file are:
+1. SPARC command: either use `command` to set a full shell string to
+   run the SPARC program, or use the combination of `sparc_exe` and
+   `mpi_prefix`. See [SPARC command configuration](#sparc-cmd-setting)
+   for more details.
+2. JSON schema settings (*Optional*): use either `json_schema` to
+   define a custom JSON schema file, or `doc_path` for parsing the
+   LaTeX documentation on-the-fly. See [JSON schema
+   configuration](#json-schema-setting) for more details.
+3. Pseudopotential settings (*Optional*): use `pp_path` for the
+   location of pseudopotential files. See [pseudopotential files settings](#pseudopot-setting)
+   for more details.
+
+
+You can overwrite the location of the configuration file by the
+environmental variable `ASE_CONFIG_PATH`.
+
+(json-schema-setting)=
 ### JSON schema
 
 Each version of SPARC-X-API ships with a JSON schema compatible with a
@@ -31,19 +78,23 @@ dated-version of SPARC C/C++ code. You can find that version in the README badge
 
 If that does not match your local SPARC version, you can configure the location of JSON schema using one of the following methods:
 
-1. Set the `$SPARC_DOC_PATH` variable
+#### Option 1. Parse LaTeX documentation on-the-fly
 
-`$SPARC_DOC_PATH` will direct SPARC-X-API to look for a local directory containing LaTeX documentation, for example:
+The environment variable `SPARC_DOC_PATH` (equivalent to `doc_path` field in configuration file)  will direct SPARC-X-API to look for a local directory containing LaTeX documentation to parse on-the-fly, for example:
 ```bash
 export SPARC_DOC_PATH=<local-SPARC-dir>/doc/.LaTeX
 ```
-and parse the JSON schema on-the-fly.
+or configuration file setting:
+```{code} ini
+doc_path: <local-SPARC-dir>/doc/.LaTeX
+```
 
-2. Use your own `parameters.json`
+
+#### 2. Use your own `parameters.json`
 
 In some cases an experimental feature may not have been updated in the
-official doc. You can create and edit your own `parameters.json` file to
-temporarily test a local version of SPARC:
+official doc. You can create and edit your own `parameters.json` file
+to temporarily test a local version of SPARC:
 
 First parse the LaTeX files into `parameters.json`
 ```bash
@@ -72,66 +123,31 @@ Then add / edit missing parameters in the `parameters` section in
   },
 ```
 
-**TODO** make sure the json parameters are included.
-Finally, set up **TODO**.
+Finally, set the `json_schema` field in the configuration file to the
+newly generated json file, for example:
+```{code} ini
+[sparc]
+; `json_schema`: custom schema file parsed from LaTeX documentation
+json_schema: ~/SPARC/parameters.json
+```
 
-<!--t `SPARC-X-API` is engineered for compatibility with the SPARC -->
-<!-- C-code. It achieves this by loading a JSON schema for --> <!--
-parameter validation and unit conversion. You can review the default
---> <!-- schema used by the API at
-sparc.sparc_json_api.default_json_api -->
+```{warning}
+`json_schema` and `doc_path` fields cannot be both present in the configuration file!
+```
 
-<!-- ```json -->
-<!-- "FD_GRID": { -\-> -->
-<!-- "symbol": "FD_GRID", -\-> -->
-<!-- <\!--    "label": "FD_GRID", -\-> -->
-<!-- <\!--    "type": "integer array", -\-> -->
-<!-- <\!--    "default": null, -\-> -->
-<!-- <\!--    "unit": "No unit", -\-> -->
-<!-- <\!--    "example": "FD_GRID: 26 26 30", -\-> -->
-<!-- <\!--    "description": "#<Some description...>", -\-> -->
-<!-- <\!--    "allow_bool_input": false, -\-> -->
-<!-- <\!--    "category": "system" -\-> -->
-<!-- <\!--   }, -\-> -->
-<!-- <\!-- ``` -\-> -->
-
-<!-- <\!-- The schema file is generated from SPARC's LaTeX documentation.  In -\-> -->
-<!-- <\!-- upcoming releases of `SPARC-X-API`, we're aiming to provide users the -\-> -->
-<!-- <\!-- flexibility to use their own custom schema files. This would be -\-> -->
-<!-- <\!-- particularly useful for those who might be testing a development -\-> -->
-<!-- <\!-- branch of SPARC. By default, the JSON schema is packaged under -\-> -->
-<!-- <\!-- `sparc/sparc_json_api` directory. If you have another version of SPARC -\-> -->
-<!-- source code, you can set the environment variable `$SPARC_DOC_PATH` to -->
-<!-- the directory containing the LaTeX codes for the documentation, such -->
-<!-- as `<SPARC-source-code-root>/doc/.LaTeX`. If you obtain `sparc-x` from -->
-<!-- the conda method as mentioned above, By default, the JSON schema is -->
-<!-- packaged under `sparc/sparc_json_api` directory. If you have another -->
-<!-- version of SPARC source code, you can set the environment variable -->
-<!-- `$SPARC_DOC_PATH` is automatically set to -->
-<!-- `<conda-env-root>/share/doc/sparc/.LaTeX`. Setting up the environment -->
-<!-- variable `$SPARC_DOC_PATH` helps loading the correct JSON schame that -->
-<!-- is compatible with your SPARC binary code. -->
-
-
+(pseudopot-setting)=
 ### Pseudopotential files
 
-Pseudopotential files (in `Abinit` [psp8 format](https://docs.abinit.org/developers/psp8_info/) are loaded in the
-following order:
 
-<!-- 1. Via the `psp_dir` argument passed to the `sparc.SPARC` calculator. -->
-<!-- 2. Through the environment variables `$SPARC_PSP_PATH` or `$SPARC_PP_PATH` (this is the -->
-<!--  method employed by [`conda` installation](#use-conda)). -->
-<!-- (manual-psp8)= -->
-<!-- 3. By using `psp8` files bundled with the SPARC-X-API installation (see the -->
-<!-- [pip installation](#pip-install)). -->
-
-To specify a custom path for your pseudopotential files (in Abinit [psp8 format]()),
-use the environment variable `$SPARC_PSP_PATH` or `$SPARC_PP_PATH` variable:
+To specify a custom path for your pseudopotential files (in Abinit [psp8 format](https://docs.abinit.org/developers/psp8_info/#:~:text=The%20format%208%20for%20ABINIT,great%20flexibility%20in%20doing%20so.),
+you can either use the environment variable `SPARC_PSP_PATH`:
 ```bash
 export SPARC_PSP_PATH=path/to/your/psp8/directory
 ```
-
-**TODO** we should sunset the `SPARC_PP_PATH`
+or the equivalent keyword `psp_path` in configuration file
+```{code} ini
+psp_path: path/to/your/psp8/directory
+```
 
 When installing SPARC [via `conda-forge`](#use-conda),
 `$SPARC_PSP_PATH` is already included in the activate script of the
@@ -143,26 +159,37 @@ To determine the location of default psp8 files (as in [manual pip installation]
 python -c "from sparc.common import psp_dir; print(psp_dir)"
 ```
 
-
+(sparc-cmd-setting)=
 ### SPARC Command Configuration
 
 The command to execute SPARC calculations is determined based on the
 following priority:
 
 1. The command argument provided directly to the `sparc.SPARC` calculator.
-2. The environment variable `$ASE_SPARC_COMMAND`
+2. Command defined by environment variable `ASE_SPARC_COMMAND` or configuration file
 3. If neither of the above is defined, `SPARC-X-API` looks for the SPARC binary under current `$PATH` and combine with the suitable MPI command prefix.
 
-Example to set `$ASE_SPARC_COMMAND`
+#### Use full command
+
+The variable `ASE_SPARC_COMMAND` (or `command` field in configuration file)
+contain the *full command* to run a SPARC calculation. depending on the system, you may choose one of the following:
 
 1. Using `mpirun` (e.g. on a single test machine)
 ```bash
 export ASE_SPARC_COMMAND="mpirun -n 8 -mca orte_abort_on_non_zero_status 1 /path/to/sparc -name PREFIX"
 ```
+or in configuration file
+```{code} ini
+command: mpirun -n 8 -mca orte_abort_on_non_zero_status 1 /path/to/sparc -name PREFIX
+```
 
 2. Using `srun` (e.g. [SLURM](https://slurm.schedmd.com/documentation.html) job system HPCs)
 ```bash
 export ASE_SPARC_COMMAND="srun -n 8 --kill-on-bad-exit /path/to/sparc -name PREFIX"
+```
+or in configuration file
+```{code} ini
+command: srun -n 8 --kill-on-bad-exit /path/to/sparc -name PREFIX" /path/to/sparc -name PREFIX
 ```
 
 ```{note}
@@ -170,6 +197,10 @@ export ASE_SPARC_COMMAND="srun -n 8 --kill-on-bad-exit /path/to/sparc -name PREF
 
 2. We recommend adding kill switches for your MPI commands like the examples above when running `sparc` to avoid unexpected behaviors with exit signals.
 ```
+
+#### Specifying MPI binary location
+
+It is also possible to construct the SPARC command from two
 
 ## Post-installation check
 

--- a/sparc/calculator.py
+++ b/sparc/calculator.py
@@ -462,6 +462,8 @@ class SPARC(FileIOCalculator, IOContext):
         else:
             extras = extras.strip()
 
+        print(self.command)
+
         # User-provided command (and properly initialized) should have
         # highest priority
         if (self.command is not None) and (
@@ -472,7 +474,7 @@ class SPARC(FileIOCalculator, IOContext):
         parser = self.cfg.parser["sparc"] if "sparc" in self.cfg.parser else {}
         # Get sparc command from either env variable or ini
         command_env = self.cfg.get("ASE_SPARC_COMMAND", None) or parser.get(
-            "sparc_command", None
+            "command", None
         )
 
         # Get sparc binary and mpi-prefix (alternative)

--- a/sparc/calculator.py
+++ b/sparc/calculator.py
@@ -147,6 +147,7 @@ class SPARC(FileIOCalculator, IOContext):
         if label is None:
             label = "SPARC" if restart is None else None
 
+        # Use psp dir from user input or env
         self.sparc_bundle = SparcBundle(
             directory=Path(self.directory),
             mode="w",
@@ -154,6 +155,7 @@ class SPARC(FileIOCalculator, IOContext):
             label=label,  # The order is tricky here. Use label not self.label
             psp_dir=psp_dir,
             validator=self.validator,
+            cfg=self.cfg,
         )
 
         # Try restarting from an old calculation and set results

--- a/sparc/io.py
+++ b/sparc/io.py
@@ -190,7 +190,7 @@ class SparcBundle:
                     return Path(env_psp_dir)
             # Use pp_path field in cfg
             parser = self.cfg.parser["sparc"] if "sparc" in self.cfg.parser else {}
-            psp_dir_ini = parser.get("pp_path", None)
+            psp_dir_ini = parser.get("psp_path", None)
             if psp_dir_ini:
                 return sanitize_path(psp_dir_ini)
             # At this point, we try to use the psp files bundled with sparc

--- a/sparc/quicktest.py
+++ b/sparc/quicktest.py
@@ -407,7 +407,7 @@ def main():
         cprint(
             "Please check additional information from:\n"
             "1. SPARC's documentation: https://github.com/SPARC-X/SPARC/blob/master/doc/Manual.pdf \n"
-            "2. Python API documentation: https://github.com/alchem0x2A/SPARC-X-API/blob/master/README.md\n",
+            "2. Python API documentation: https://sparc-x.github.io/SPARC-X-API\n",
             color=None,
         )
 

--- a/sparc/utils.py
+++ b/sparc/utils.py
@@ -161,7 +161,7 @@ def sanitize_path(path_string):
     """
     if isinstance(path_string, str):
         path = os.path.expandvars(os.path.expanduser(path_string))
-        path = path.resolve()
+        path = Path(path).resolve()
     else:
         path = Path(path_string).resolve()
     return path
@@ -178,7 +178,7 @@ def locate_api(json_file=None, doc_path=None, cfg=_cfg):
     3) If both `json_file` and `doc_path` are provided, raise an exception.
     4) Fallback to the default API setup if neither is provided.
     """
-    parser = cfg.parser.get("sparc") if "sparc" in cfg.parser else {}
+    parser = cfg.parser["sparc"] if "sparc" in cfg.parser else {}
     if not json_file:
         json_file = parser.get("json_schema") if parser else None
 


### PR DESCRIPTION
This PR adds support for the configuration file `~/.config/ase/config.ini` to include a sparc section

An example of the ini section may be 
```ini
[sparc]
; `command`: full shell command (include MPI directives) to run SPARC
command = srun -n 24 path/to/sparc

; `pp_path`: directory containing pseudopotential files (optional)
pp_path = path/to/SPARC/psps

; `doc_path`: directory for SPARC LaTeX documentation to build JSON schema on the fly (optional)
doc_path = path/to/SPARC/doc/.LaTeX/
```

where the configurations can be used for SPARC calculator, sparc.io, and JSON API modules

@ltimmerman3 @ajmedford  please take a look if the proposed keywords in sparc configure section makes sense to you

### SPARC command
Equivalent to ASE_SPARC_COMMAND
```ini
command = srun -n 24 path/to/sparc 
```

or mix of mpi prefix and sparc binary path
```ini
sparc_exe = path/to/sparc
mpi_prefix = srun -n 24 --more-flags
```

The latter is more straightforward (although not cannonical ASE), and may benefit issues like #46, but I don't know if the keywords will be meaningful in the longrun


### Defining custom schema
Either specify the path to LaTeX doc (equivalent to `ASE_DOC_PATH`)
```ini
doc_path = ~/dev_SPARC/doc/.LaTeX
```

or specify the path to a custom json schema
```ini
json_schema = ~/dev_SPARC/parameters.json
```

### Psp location
Through `psp_path` (equivalent to SPARC_PSP_PATH)
```ini
psp_path = ~/dev_SPARC/psps
```
