### PR TITLE
Minimal pyproject.toml to suppress deprecation errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,9 @@
+# A minimal pyproject.toml to make the pip installation
+# future-proof. The latest setuptools should be able to
+# suppress deprecation warnings for editable installation
+# https://github.com/pypa/pip/issues/11457
+#
+# Note: the actual installation is still handled by setup.py
+[build-system]
+requires = ["setuptools >= 64", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Although the `setup.py` is still very acceptable way of python packaging, according to https://github.com/pypa/pip/issues/11457, using setup.py alone for editable installation will be dropped by newer versions
of pip. A minimal pyproject.toml is added to supplement the current setup.py, as some pythonic expressions isn't readily available for direct transition to pyproject.toml yet