### PR TITLE
Fix links and output display in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ guidelines.
 ## How to cite
 If you find SPARC-X-API help, please consider cite the relevant
 publications below:
-- The SPARC-X-API package itself: [Tian et al. 2024]()
+- The SPARC-X-API package itself: [Tian et al. 2024](https://github.com/openjournals/joss-reviews/issues/7747)
 - The SPARC C/C++ code
   - v2.0 [Zhang et al., 2024](https://doi.org/10.1016/j.simpa.2024.100649)
   - v1.0 [Xu et al., 2021](https://doi.org/10.1016/j.softx.2021.100709)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Install the pre-compiled SPARC binary alongside SPARC-X-API (Linux only).
 conda install -c conda-forge sparc-x
 ```
 
-*Note: the official SPARC binary in the conda-forge channel does not come with [socket support]() yet. Please follow this [instruction]() if you wish to install socket-compatible SPARC code*
+*Note: the official SPARC binary in the conda-forge channel does not come with [socket support](https://github.com/SPARC-X/SPARC-X-API?tab=readme-ov-file#socket-mode) yet. Please follow this [instruction](https://sparc-x.github.io/SPARC-X-API/installation.html#manual-compilation-of-the-sparc-binary-code) if you wish to install socket-compatible SPARC code*
 
 ### Setup SPARC-X-API
 
@@ -94,8 +94,8 @@ atoms = read("sparc_calc_dir/", format="sparc")
 - Write input files
 ```python
 # `format="sparc"` should be specified
-from ase.build import Bulk
-atoms = Bulk("Al") * [4, 4, 4]
+from ase.build import bulk
+atoms = bulk("Al") * [4, 4, 4]
 atoms.write("sparc_calc_dir/", format="sparc")
 ```
 
@@ -155,7 +155,7 @@ atoms.get_forces()
 ```
 
 #### Socket mode
-*Note: A socket-compatible SPARC binary installation is required. Please check this [instruction]() for more details.*
+*Note: A socket-compatible SPARC binary installation is required. Please check this [instruction](https://sparc-x.github.io/SPARC-X-API/installation.html#manual-compilation-of-the-sparc-binary-code) for more details.*
 
 Switching to the socket mode requires just a few parameters, ideal for
 workflows with hundreds or thousands of single point DFT calls with
@@ -168,7 +168,7 @@ from ase.build import molecule
 from ase.optimize import BFGS
 atoms = molecule("H2", cell=(10, 10, 10), pbc=False)
 atoms.center()
-atoms.calc = SPARC(h=0.25, , directory="run_sp", use_socket=True) # 0.25 Å mesh spacing
+atoms.calc = SPARC(h=0.25, directory="run_sp", use_socket=True) # 0.25 Å mesh spacing
 opt = BFGS(atoms)
 with atoms.calc:
     opt.run(fmax=0.01)

--- a/doc/contribute.md
+++ b/doc/contribute.md
@@ -16,6 +16,7 @@ information:
 
 We recommend the following steps to setup the test environment and modify codes.
 
+(dev-env-setup)=
 ### Setting up environment
 
 We recommend to work in a clean conda environment (or virtualenv),
@@ -146,6 +147,6 @@ Please check the [maintenance guide](maintainers.md) for roles
 involving admin privileges.
 
 ```{toctree}
-:max_depth: 1
+:maxdepth: 1
 test_coverage.md
 ```

--- a/doc/examples/external_mlff.md
+++ b/doc/examples/external_mlff.md
@@ -102,4 +102,4 @@ with SPARC(use_socket=True, **calc_params) as calc:
     dyn.run(10)
 ```
 
-The full script can be downloaded [here](https://github.com/SPARC-X/SPARC-X-API/blob/master/examples/socket/md/mlff/plumed/run.py).
+The full script can be downloaded [here](https://raw.githubusercontent.com/SPARC-X/SPARC-X-API/refs/heads/master/examples/socket/md/mlff/plumed/run.py).

--- a/doc/examples/geopt_compare.md
+++ b/doc/examples/geopt_compare.md
@@ -79,7 +79,7 @@ calculations:
 You can overcome these using the socket mode, effectively by just
 invoking the `use_socket=True` flag in above case.
 ```{note}
-Make sure your SPARC binary is compiled with socket support. See [installation guide](installation.md) for more details.
+Make sure your SPARC binary is compiled with socket support. See [installation guide](../installation.md) for more details.
 ```
 
 ```{code} python
@@ -106,7 +106,7 @@ Example outputs from the different ways of running the optimization
 are as follows:
 
 SPARC internal LBFGS routine
-```{raw}
+```
 SPARC internal LBFGS:
 Final energy: -330.8388527992713 eV
 Final fmax: 0.014610782237434465 eV/Ang
@@ -114,7 +114,7 @@ N steps: 23
 ```
 
 ASE LBFGS + file I/O mode
-```{raw}
+```
 ASE LBFGS
 Final energy: -330.8460713860338 eV
 Final fmax: 0.008090338967301871 eV/Ang
@@ -122,7 +122,7 @@ N steps: 21
 ```
 
 ASE LBFGS + socket I/O mode
-```{raw}
+```
 ASE LBFGS (socket mode)
 Final energy: -330.8356141220578 eV
 Final fmax: 0.015431850436823448 eV/Ang

--- a/doc/examples/internal_mlff.md
+++ b/doc/examples/internal_mlff.md
@@ -9,7 +9,7 @@ be accessed via the API by passing the appropriate sparc flags to the
 available in the [SPARC
 documentation](https://github.com/SPARC-X/SPARC/tree/master/doc).
 
-The full python script for training MLFF using SPARC calculated geometric relaxation data can be downloaded [here](https://github.com/SPARC-X/SPARC-X-API/blob/master/examples/FileIO/relax/relax_coords/mlff/run.py).
+The full python script for training MLFF using SPARC calculated geometric relaxation data can be downloaded [here](https://raw.githubusercontent.com/SPARC-X/SPARC-X-API/refs/heads/master/examples/FileIO/relax/relax_coords/mlff/run.py).
 
 The primary flag of interest is the `MLFF_FLAG` which must be set to `1` to train a MLFF from scratch. This needs to be included in a parameter dictionary that will later be passed to a SPARC calculator instance:
 
@@ -106,4 +106,4 @@ with SPARC(use_socket=True, **calc_params) as calc:
 
 A MLFF is still trained on-the-fly using SPARC DFT energies, forces, and stresses; but the structures are generated from the `ASE` optimization algorithm.
 
-The full script for socket-enabled MLFF training and optimization can be downloaded [here](https://github.com/SPARC-X/SPARC-X-API/blob/master/examples/socket/relax/mlff/coords/run.py).
+The full script for socket-enabled MLFF training and optimization can be downloaded [here](https://raw.githubusercontent.com/SPARC-X/SPARC-X-API/refs/heads/master/examples/socket/md/mlff/plumed/run.py).

--- a/doc/examples/simple_dft.md
+++ b/doc/examples/simple_dft.md
@@ -63,7 +63,7 @@ if __name__ == "__main__":
 ```
 
 The output from the above example may look like:
-```{raw}
+```
 Fitted volume (Ang^3), energy (eV), modulus (eV/Ang^3)
 65.97840834969949 -253.07755156337953 2.9095110471623173
 Optimal cell length (cubic): 4.040799280428726 Ang

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -91,7 +91,7 @@ python -m sparc.download_data
 
 
 For developers, please check the [how to
-contribute](#setting-up-environment) page for setting up a dev-environment for SPARC-X-API.
+contribute](#dev-env-setup) page for setting up a dev-environment for SPARC-X-API.
 
 ```{note}
 Please avoid mixing `conda` and `pip` installations for the same package like `sparc-x-api` in the same environment, as this may lead to unexpected behavior.

--- a/sparc/io.py
+++ b/sparc/io.py
@@ -988,6 +988,9 @@ def read_sparc_aimd(filename, index=-1, **kwargs):
 read_aimd = read_sparc_aimd
 
 
+@deprecated(
+    "__register_new_filetype will be deprecated for future releases. Please upgrade ase>=3.23."
+)
 def __register_new_filetype():
     """Register the filetype() function that allows recognizing .sparc as directory
     This method should only be called for ase==3.22 compatibility and for ase-gui


### PR DESCRIPTION
Related to #97 #99. Fixed a few typos in README examples and added links to runnable python scripts in documentation