### PR TITLE
Fixing bug in reading atomic magnetic moments as list instead of array

### DIFF
--- a/sparc/io.py
+++ b/sparc/io.py
@@ -552,9 +552,7 @@ class SparcBundle:
                 partial_results["forces"] = static_results["forces"][self.resort]
 
             if "atomic_magnetization" in static_results:
-                partial_results["magmoms"] = static_results["atomic_magnetization"][
-                    self.resort
-                ]
+                partial_results["magmoms"] = static_results["atomic_magnetization"][self.resort]
 
             if "net_magnetization" in static_results:
                 partial_results["magmom"] = static_results["net_magnetization"]

--- a/sparc/sparc_parsers/static.py
+++ b/sparc/sparc_parsers/static.py
@@ -80,6 +80,11 @@ def _read_static_block(raw_block):
         name = "net_magnetization"
     elif "Atomic magnetization" in header_name:
         name = "atomic_magnetization"
+        if type(value) is list:
+            try:
+                value = np.array(value)
+            except:
+                print("Cannot convert atomic magnetization to array")
     elif "Stress (GPa)" in header_name:
         name = "stress"
     elif "Stress equiv." in header_name:


### PR DESCRIPTION
Cannot pass self.resort to list, must be array. Seems that the atomic magnetizations are read as a list.