### PR TITLE
add the future-proof ase v4 plugin method

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,10 @@ setup(
     packages=find_packages(),
     install_requires=["ase>=3.23.0", "numpy>=1.23", "packaging>=20.0", "psutil>=5.0.0"],
     entry_points={
+        # Use the new ASE-4 format plugin system
+        "ase.plugins": [                                                              
+           "sparc = sparc.ase_plugins",
+       ], 
         # The ioformats are only compatible with ase>=3.23
         "ase.ioformats": [
             "sparc = sparc.io:format_sparc",

--- a/sparc/ase_plugins.py
+++ b/sparc/ase_plugins.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+# ASE 4 experimental plugin declaration for SPARC-X-API.
+# This module is loaded through the ``ase.plugins`` entry point and uses the
+# ``ase._4.plugins`` plugin system introduced for ASE 4 calculator discovery.
+
+try:
+    from ase._4.plugins.calculator import CalculatorPlugin
+except ImportError:
+    # ASE < 4 does not provide the new plugin system.  Older ASE versions will
+    # not consume the ``ase.plugins`` entry point, but keeping this module
+    # importable avoids surprising failures if users/tools import it directly.
+    __ase_plugins__ = set()
+else:
+    sparc_plugin = CalculatorPlugin(
+        name="sparc",
+        long_name="Python API for SPARC-X code (FileIO and SocketIO)",
+        citation="SPARC-X / SPARC-X-API developers",
+        implementation="sparc.calculator.SPARC",
+        configurable=True,  # uses ase.config / external executable config
+    )
+
+    __ase_plugins__ = {sparc_plugin}


### PR DESCRIPTION
In the upcoming v4 of ASE the plugin system will be implemented to allow `ase info --plugins` to search for all known file IO formats and calculators (for this branch https://gitlab.com/ase/ase/-/blob/ase4-plugins-all-calculators/ase/codes.py?ref_type=heads)

After the ASE_4 releases the following should work 
```bash
ase info --plugins
```

Showing 

```
sparc 1.1.1.dev10+gdd95a7489.d20260617 — Python API for the SPARC DFT Code
==========================================================================

Provides:

IOFormatPlugin
--------------
sparc, sparc_aimd, sparc_geopt, sparc_ion, sparc_static

CalculatorPlugin
----------------
sparc
```